### PR TITLE
Course discovery service customization

### DIFF
--- a/course_discovery/apps/api/pagination.py
+++ b/course_discovery/apps/api/pagination.py
@@ -1,5 +1,38 @@
 from rest_framework import pagination
+from rest_framework.response import Response
 
 
 class PageNumberPagination(pagination.PageNumberPagination):
     page_size_query_param = 'page_size'
+
+
+class NamespacedPageNumberPagination(pagination.PageNumberPagination):
+    """
+    Rjio custom: Pagination scheme that returns results with pagination metadata
+    embedded in a "pagination" attribute.  Can be used with data
+    that comes as a list of items, or as a dict with a "results"
+    attribute that contains a list of items.
+    """
+
+    page_size_query_param = "page_size"
+
+    def get_paginated_response(self, data):
+        """
+        Annotate the response with pagination information
+        """
+        metadata = {
+            'next': self.get_next_link(),
+            'previous': self.get_previous_link(),
+            'count': self.page.paginator.count,
+            'num_pages': self.page.paginator.num_pages,
+        }
+        if isinstance(data, dict):
+            if 'results' not in data:
+                raise TypeError(u'Malformed result dict')
+            data['pagination'] = metadata
+        else:
+            data = {
+                'results': data,
+                'pagination': metadata,
+            }
+        return Response(data)

--- a/course_discovery/apps/api/serializers.py
+++ b/course_discovery/apps/api/serializers.py
@@ -198,6 +198,7 @@ class CourseRunSerializer(TimestampModelSerializer):
             'enrollment_start', 'enrollment_end', 'announcement', 'image', 'video', 'seats',
             'content_language', 'transcript_languages', 'instructors', 'staff',
             'pacing_type', 'min_effort', 'max_effort', 'modified', 'marketing_url',
+            'display_organization', 'enable_jvc', 'room_key',
         )
 
     def get_marketing_url(self, obj):

--- a/course_discovery/apps/api/v1/views.py
+++ b/course_discovery/apps/api/v1/views.py
@@ -24,7 +24,7 @@ from rest_framework.response import Response
 
 from course_discovery.apps.api import serializers
 from course_discovery.apps.api.filters import PermissionsFilter, HaystackFacetFilterWithQueries
-from course_discovery.apps.api.pagination import PageNumberPagination
+from course_discovery.apps.api.pagination import PageNumberPagination, NamespacedPageNumberPagination
 from course_discovery.apps.api.renderers import AffiliateWindowXMLRenderer, CourseRunCSVRenderer
 from course_discovery.apps.catalogs.models import Catalog
 from course_discovery.apps.core.utils import SearchQuerySetWrapper
@@ -177,6 +177,7 @@ class CourseViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Course.objects.all()
     permission_classes = (IsAuthenticated,)
     serializer_class = serializers.CourseSerializer
+    pagination_class = NamespacedPageNumberPagination
 
     def get_queryset(self):
         q = self.request.query_params.get('q', None)
@@ -213,6 +214,7 @@ class CourseRunViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = CourseRun.objects.all().order_by(Lower('key'))
     permission_classes = (IsAuthenticated,)
     serializer_class = serializers.CourseRunSerializer
+    pagination_class = NamespacedPageNumberPagination
 
     def get_queryset(self):
         q = self.request.query_params.get('q', None)
@@ -285,7 +287,7 @@ class ProgramViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class ManagementViewSet(viewsets.ViewSet):
-    permission_classes = (IsSuperuser,)
+    permission_classes = (IsAuthenticated,)
 
     @list_route(methods=['post'])
     def refresh_course_metadata(self, request):
@@ -300,7 +302,8 @@ class ManagementViewSet(viewsets.ViewSet):
               multiple: false
         """
         access_token = request.data.get('access_token')
-        kwargs = {'access_token': access_token} if access_token else {}
+        token_type = request.data.get('token_type')
+        kwargs = {'access_token': access_token, 'token_type': token_type} if access_token else {}
         name = 'refresh_course_metadata'
 
         output = self.run_command(request, name, **kwargs)

--- a/course_discovery/apps/course_metadata/data_loaders.py
+++ b/course_discovery/apps/course_metadata/data_loaders.py
@@ -186,7 +186,8 @@ class CoursesApiDataLoader(AbstractDataLoader):
                 page = None
 
             for body in results:
-                course_run_id = body['id']
+                # Rjio fix: for Dogwood backporting change all body['id'] to body['course_id']
+                course_run_id = body['course_id']
 
                 try:
                     body = self.clean_strings(body)
@@ -202,7 +203,7 @@ class CoursesApiDataLoader(AbstractDataLoader):
     def update_course(self, body):
         # NOTE (CCB): Use the data from the CourseKey since the Course API exposes display names for org and number,
         # which may not be unique for an organization.
-        course_run_key_str = body['id']
+        course_run_key_str = body['course_id']
         course_run_key = CourseKey.from_string(course_run_key_str)
         organization, __ = Organization.objects.get_or_create(key=course_run_key.org)
         course_key = self.convert_course_run_key(course_run_key_str)
@@ -229,8 +230,12 @@ class CoursesApiDataLoader(AbstractDataLoader):
             'video': self.get_courserun_video(body),
             'pacing_type': self.get_pacing_type(body),
             'image': self.get_courserun_image(body),
+            # Rjio Added fields display_organization, enable_jvc, room_key
+            'display_organization': body['org'],
+            'enable_jvc': body['enable_jvc'],
+            'room_key': body['room_key'],
         }
-        CourseRun.objects.update_or_create(key=body['id'], defaults=defaults)
+        CourseRun.objects.update_or_create(key=body['course_id'], defaults=defaults)
 
     def get_pacing_type(self, body):
         pacing = body.get('pacing')
@@ -434,7 +439,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
         self.delete_orphans()
 
     def update_seats(self, body):
-        course_run_key = body['id']
+        course_run_key = body['course_id']
         try:
             course_run = CourseRun.objects.get(key=course_run_key)
         except CourseRun.DoesNotExist:

--- a/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
+++ b/course_discovery/apps/course_metadata/management/commands/refresh_course_metadata.py
@@ -53,11 +53,12 @@ class Command(BaseCommand):
                 logger.exception('No access token provided or acquired through client_credential flow.')
                 raise
 
+        # Rjio comment the other data loaders which are not used.
         loaders = (
-            (OrganizationsApiDataLoader, settings.ORGANIZATIONS_API_URL,),
+            # (OrganizationsApiDataLoader, settings.ORGANIZATIONS_API_URL,),
             (CoursesApiDataLoader, settings.COURSES_API_URL,),
-            (EcommerceApiDataLoader, settings.ECOMMERCE_API_URL,),
-            (DrupalApiDataLoader, settings.MARKETING_API_URL,),
+            # (EcommerceApiDataLoader, settings.ECOMMERCE_API_URL,),
+            # (DrupalApiDataLoader, settings.MARKETING_API_URL,),
         )
 
         for loader_class, api_url in loaders:

--- a/course_discovery/apps/course_metadata/migrations/0006_auto_20160714_1004.py
+++ b/course_discovery/apps/course_metadata/migrations/0006_auto_20160714_1004.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_metadata', '0005_auto_20160713_0113'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='courserun',
+            name='display_organization',
+            field=models.CharField(null=True, max_length=255, blank=True, default=None),
+        ),
+        migrations.AddField(
+            model_name='courserun',
+            name='enable_jvc',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='courserun',
+            name='room_key',
+            field=models.TextField(null=True),
+        ),
+        migrations.AddField(
+            model_name='historicalcourserun',
+            name='display_organization',
+            field=models.CharField(null=True, max_length=255, blank=True, default=None),
+        ),
+        migrations.AddField(
+            model_name='historicalcourserun',
+            name='enable_jvc',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='historicalcourserun',
+            name='room_key',
+            field=models.TextField(null=True),
+        ),
+        migrations.AlterField(
+            model_name='course',
+            name='short_description',
+            field=models.TextField(null=True, blank=True, default=None),
+        ),
+        migrations.AlterField(
+            model_name='courserun',
+            name='short_description_override',
+            field=models.TextField(help_text="Short description specific for this run of a course. Leave this value blank to default to the parent course's short_description attribute.", null=True, blank=True, default=None),
+        ),
+        migrations.AlterField(
+            model_name='historicalcourse',
+            name='short_description',
+            field=models.TextField(null=True, blank=True, default=None),
+        ),
+        migrations.AlterField(
+            model_name='historicalcourserun',
+            name='short_description_override',
+            field=models.TextField(help_text="Short description specific for this run of a course. Leave this value blank to default to the parent course's short_description attribute.", null=True, blank=True, default=None),
+        ),
+    ]

--- a/course_discovery/apps/course_metadata/models.py
+++ b/course_discovery/apps/course_metadata/models.py
@@ -127,7 +127,8 @@ class Course(TimeStampedModel):
     """ Course model. """
     key = models.CharField(max_length=255, db_index=True, unique=True)
     title = models.CharField(max_length=255, default=None, null=True, blank=True)
-    short_description = models.CharField(max_length=255, default=None, null=True, blank=True)
+    # Rjio Changed short_description to text type
+    short_description = models.TextField(default=None, null=True, blank=True)
     full_description = models.TextField(default=None, null=True, blank=True)
     organizations = models.ManyToManyField('Organization', through='CourseOrganization', blank=True)
     subjects = models.ManyToManyField(Subject, blank=True)
@@ -212,8 +213,8 @@ class CourseRun(TimeStampedModel):
     enrollment_start = models.DateTimeField(null=True, blank=True)
     enrollment_end = models.DateTimeField(null=True, blank=True)
     announcement = models.DateTimeField(null=True, blank=True)
-    short_description_override = models.CharField(
-        max_length=255, default=None, null=True, blank=True,
+    short_description_override = models.TextField(
+        default=None, null=True, blank=True,
         help_text=_(
             "Short description specific for this run of a course. Leave this value blank to default to "
             "the parent course's short_description attribute."))
@@ -237,6 +238,10 @@ class CourseRun(TimeStampedModel):
     image = models.ForeignKey(Image, default=None, null=True, blank=True)
     video = models.ForeignKey(Video, default=None, null=True, blank=True)
     marketing_url = models.URLField(max_length=255, null=True, blank=True)
+    # Rjio custom add
+    display_organization = models.CharField(max_length=255, default=None, null=True, blank=True)
+    enable_jvc = models.BooleanField(default=False)
+    room_key = models.TextField(null=True)
 
     history = HistoricalRecords()
 

--- a/course_discovery/apps/course_metadata/search_indexes.py
+++ b/course_discovery/apps/course_metadata/search_indexes.py
@@ -83,6 +83,8 @@ class CourseRunIndex(BaseCourseIndex, indexes.Indexable):
     seat_types = indexes.MultiValueField(model_attr='seat_types', null=True, faceted=True)
     type = indexes.CharField(model_attr='type', null=True, faceted=True)
     image_url = indexes.CharField(model_attr='image_url', null=True)
+    # Rjio add display_organization field
+    display_organization = indexes.CharField(model_attr='display_organization')
 
     def _prepare_language(self, language):
         return language.name

--- a/course_discovery/settings/base.py
+++ b/course_discovery/settings/base.py
@@ -83,7 +83,7 @@ WSGI_APPLICATION = 'course_discovery.wsgi.application'
 # Set this value in the environment-specific files (e.g. local.py, production.py, test.py)
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.',
+        'ENGINE': 'django.db.backends.mysql',
         'NAME': '',
         'USER': '',
         'PASSWORD': '',

--- a/course_discovery/settings/production.py
+++ b/course_discovery/settings/production.py
@@ -17,22 +17,37 @@ LOGGING['handlers']['local']['level'] = 'INFO'
 
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
-DICT_UPDATE_KEYS = ('JWT_AUTH',)
+DICT_UPDATE_KEYS = (
+    'COURSES_API_URL',
+    'DATABASES'
+    'EDX_DRF_EXTENSIONS',
+    'JWT_AUTH',
+    'SOCIAL_AUTH_EDX_OIDC_KEY',
+    'SOCIAL_AUTH_EDX_OIDC_SECRET',
+    'SOCIAL_AUTH_EDX_OIDC_URL_ROOT',
+    'SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY',
+)
 
 CONFIG_FILE = get_env_setting('COURSE_DISCOVERY_CFG')
-with open(CONFIG_FILE) as f:
-    config_from_yaml = yaml.load(f)
 
-    # Remove the items that should be used to update dicts, and apply them separately rather
-    # than pumping them into the local vars.
-    dict_updates = {key: config_from_yaml.pop(key, None) for key in DICT_UPDATE_KEYS}
+# Rjio fix , added setting overiding support from yml file
+# Note: In case of dictonary keys should be defined in yml file.
+if CONFIG_FILE:
+    with open(CONFIG_FILE) as f:
+        config_from_yaml = yaml.load(f)
 
-    for key, value in dict_updates.items():
-        if value:
-            vars()[key].update(value)
+        # Remove the items that should be used to update dicts, and apply them separately rather
+        # than pumping them into the local vars.
+        dict_updates = {key: config_from_yaml.pop(key, None) for key in DICT_UPDATE_KEYS}
 
-    vars().update(config_from_yaml)
+        for key, value in dict_updates.items():
+            if value:
+                # Rjio override values from yml file
+                vars()[key] = value
 
+        vars().update(config_from_yaml)
+
+# Rjio DB settings are loaded from the config file
 DB_OVERRIDES = dict(
     PASSWORD=environ.get('DB_MIGRATION_PASS', DATABASES['default']['PASSWORD']),
     ENGINE=environ.get('DB_MIGRATION_ENGINE', DATABASES['default']['ENGINE']),
@@ -41,6 +56,10 @@ DB_OVERRIDES = dict(
     HOST=environ.get('DB_MIGRATION_HOST', DATABASES['default']['HOST']),
     PORT=environ.get('DB_MIGRATION_PORT', DATABASES['default']['PORT']),
 )
+
+# Rjio fix
+ELASTICSEARCH_URL = "http://localhost:9200/"
+ELASTICSEARCH_INDEX_NAME = "catalog"
 
 HAYSTACK_CONNECTIONS['default'].update({
     'URL': ELASTICSEARCH_URL,

--- a/course_discovery/settings/utils.py
+++ b/course_discovery/settings/utils.py
@@ -6,7 +6,8 @@ from django.core.exceptions import ImproperlyConfigured
 def get_env_setting(setting):
     """ Get the environment setting or raise exception """
     try:
-        return environ[setting]
+        # Rjio setting is obtained with get method
+        return environ.get(setting, None)
     except KeyError:
         error_msg = "Set the [{}] env variable!".format(setting)
         raise ImproperlyConfigured(error_msg)

--- a/course_discovery/wsgi.py
+++ b/course_discovery/wsgi.py
@@ -13,7 +13,7 @@ from sys import path
 SITE_ROOT = dirname(dirname(abspath(__file__)))
 path.append(SITE_ROOT)
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "course_discovery.settings.local")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "course_discovery.settings.production")
 
 from django.core.wsgi import get_wsgi_application
 


### PR DESCRIPTION
API:
   1) Change generic REST pagination to use page based pagination.
   2) Add enable_jvc, room_key and display_organization fields in course_run model/api.
      Modified course_run serializer, data_loader for courses v1 api for above changes.
   3) Change authentication class for management api.

Course Metadata:
   1) Fixed token_type parameter issue in management api.
   2) Changed short description field type to text in course and course_run
   3) Change key 'id' to 'course_id' in course api reponse's body dictionary.

Settings:
   1) The yml setting file overiding implementation is changed to support dictionary and variable.